### PR TITLE
Remove PWP::Encoding from weaver.ini

### DIFF
--- a/weaver.ini
+++ b/weaver.ini
@@ -1,3 +1,1 @@
 [@Default]
-
-[-Encoding]


### PR DESCRIPTION
Hi,

`Pod::Weaver` has `SingleEncoding` plugin now (starting from 4.000) as part of the `@Default` bundle. This makes `Pod::Weaver::Plugin::Encoding` an extra dependency that could be thrown away.

See [Rik's post](http://rjbs.manxome.org/rubric/entry/2021) and also check out my quest for details/comments:

> http://questhub.io/realm/perl/quest/5277f3cc9f567ad56f0000e7

Cheers,
Sergey
