### PR TITLE
add prereq on B::Hooks::OP::Check::Install::Files

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,7 +4,7 @@ Revision history for multidimensional
 
 0.013     2017-04-20 15:05:14+01:00 Europe/London
  - Switch to Dist::Zilla::PluginBundle::Starter
-   and ::Plugin::DymamicPrereqs
+   and ::Plugin::DynamicPrereqs
  - Use Devel::PPPort insted of hand-rolled compat macros
 
 0.012     2016-05-16 19:18:11+01:00 Europe/London

--- a/dist.ini
+++ b/dist.ini
@@ -33,6 +33,7 @@ Test::More = 0.88
 [Prereqs / ConfigureRequires]
 ExtUtils::Depends = 0
 B::Hooks::OP::Check = 0
+B::Hooks::OP::Check::Install::Files = 0
 CPAN::Meta = 2.112580
 
 [CheckChangesHasContent]


### PR DESCRIPTION
this came up at the toolchain summit -- I accidentally realeased a B-Hooks-OP-Check with the ::Install::Files module missing, but even after I released a fix, upstream modules did not pick up the fix because of the lack of an explicit dependency.